### PR TITLE
Tick command improvements

### DIFF
--- a/include/PlayerQuitListener.h
+++ b/include/PlayerQuitListener.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <endstone/endstone.hpp>
+#include <endstone/event/player/player_quit_event.h>
+
+class PlayerQuitListener {
+public:
+    explicit PlayerQuitListener(endstone::Plugin &plugin) : plugin_(plugin) {}
+
+    void onPlayerQuit(endstone::PlayerQuitEvent &event) {
+        TickSpeed::onPlayerQuit(event);
+    }
+
+private:
+    endstone::Plugin &plugin_;
+};

--- a/include/Tick.h
+++ b/include/Tick.h
@@ -14,7 +14,6 @@ public:
     static bool shouldStartStepping;
     static int sprintTicks;
     static bool shouldInterruptSprint;
-    static endstone::CommandSender *sprintSender;
     static std::chrono::time_point<std::chrono::system_clock> sprintStartDate;
 
     static endstone::Server *server;
@@ -51,18 +50,17 @@ public:
             shouldInterruptSprint = true;
             if (sprintTicks > 0) {
                 finishSprint();
-                sender.sendMessage("§7Interrupted current tick sprint.");
+                server->broadcastMessage("§7Interrupted current tick sprint.");
             }
             return;
         }
         if (sprintTicks > 0 || stepTicks > 0) {
-            sender.sendMessage("§cThe game is already sprinting.");
+            server->broadcastMessage("§cThe game is already sprinting.");
             return;
         }
-        sprintSender = &sender;
         sprintStartDate = std::chrono::system_clock::now();
         sprintTicks = ticks;
-        sender.sendMessage("§7Sprinting...", ticks);
+        server->broadcastMessage("§7Sprinting {} ticks...", ticks);
     }
 
     static void finishSprint() {
@@ -76,11 +74,7 @@ public:
         double mspt = (1.0*msToCompletion) / completedTicks;
         sprintTicks = 0;
         std::string message = fmt::format("§7Sprint completed at {} tps ({} mspt).", tps, mspt);
-        if (sprintSender != nullptr) {
-            sprintSender->sendMessage(message);
-        } else {
-            server->broadcastMessage(message);
-        }
+        server->broadcastMessage(message);
     }
 
     static bool isSprinting() {
@@ -90,6 +84,7 @@ public:
     static void onPlayerQuit(endstone::PlayerQuitEvent &event) {
         if (freezeSender != nullptr && event.getPlayer().getName() == freezeSender->getName()) {
             unfreeze();
+            server->broadcastMessage("§7Freezing player quit. The game is running normally.");
         }
     }
 
@@ -147,7 +142,6 @@ inline int TickSpeed::stepTicks = 0;
 inline bool TickSpeed::shouldStartStepping = false;
 inline int TickSpeed::sprintTicks = 0;
 inline bool TickSpeed::shouldInterruptSprint = false;
-inline endstone::CommandSender *TickSpeed::sprintSender = nullptr;
 inline std::chrono::time_point<std::chrono::system_clock> TickSpeed::sprintStartDate;
 inline endstone::Server *TickSpeed::server;
 inline endstone::Logger *TickSpeed::logger;

--- a/include/Tick.h
+++ b/include/Tick.h
@@ -4,6 +4,7 @@
 #include <endstone/event/player/player_quit_event.h>
 
 void (*minecraftAdvanceTicksFn)(void *timer, float advance);
+void (*minecraftLevelTickFn)(void *level);
 
 class TickSpeed {
 public:
@@ -11,7 +12,6 @@ public:
     static bool isFrozen;
     static endstone::CommandSender *freezeSender;
     static int stepTicks;
-    static bool shouldStartStepping;
     static int sprintTicks;
     static bool shouldInterruptSprint;
     static std::chrono::time_point<std::chrono::system_clock> sprintStartDate;
@@ -42,7 +42,6 @@ public:
 
     static void step(int ticks) {
         stepTicks += ticks;
-        shouldStartStepping = true;
     }
 
     static void sprint(endstone::CommandSender &sender, int ticks) {
@@ -54,7 +53,7 @@ public:
             }
             return;
         }
-        if (sprintTicks > 0 || stepTicks > 0) {
+        if (sprintTicks > 0) {
             server->broadcastMessage("§cThe game is already sprinting.");
             return;
         }
@@ -77,8 +76,20 @@ public:
         server->broadcastMessage(message);
     }
 
+    static bool shouldStartSprint(int32_t *realSprintTicks) {
+        return *realSprintTicks == -1 && TickSpeed::sprintTicks > 0;
+    }
+
+    static bool isDoneSprinting(int32_t *realSprintTicks) {
+        return *realSprintTicks == 0 && TickSpeed::sprintTicks > 0;
+    }
+
     static bool isSprinting() {
         return sprintTicks > 0;
+    }
+
+    static bool isStepping() {
+        return stepTicks > 0;
     }
 
     static void onPlayerQuit(endstone::PlayerQuitEvent &event) {
@@ -91,69 +102,63 @@ public:
     static void hook(void *baseAddress, funchook_t *funchook);
 };
 
-bool shouldStartSprint(int32_t *realSprintTicks) {
-    return *realSprintTicks == -1 && TickSpeed::sprintTicks > 0;
-}
-
-bool isDoneSprinting(int32_t *realSprintTicks) {
-    return *realSprintTicks == 0 && TickSpeed::sprintTicks > 0;
-}
-
-bool isDoneStepping(int32_t *realSprintTicks) {
-    return *realSprintTicks == 0 && TickSpeed::stepTicks > 0;
-}
-
-void timerHook(void *timer, float advance) {
-    if (TickSpeed::server->getOnlinePlayers().empty()) {
-        TickSpeed::unfreeze();
-    }
-    auto *realTickRate = reinterpret_cast<float *>(reinterpret_cast<char *>(timer) + 0x0);
-    *realTickRate = TickSpeed::targetTickRate;
-    if (TickSpeed::isFrozen) {
-        *realTickRate = 0.0;
-    }
-
-    auto *realSprintTicks = reinterpret_cast<int32_t *>(reinterpret_cast<char *>(timer) + 0x3C);
-    if (shouldStartSprint(realSprintTicks)) {
-        *realSprintTicks = TickSpeed::sprintTicks;
-    } else if (TickSpeed::shouldStartStepping) {
-        TickSpeed::shouldStartStepping = false;
-        *realSprintTicks = TickSpeed::stepTicks;
-    } else if (TickSpeed::shouldInterruptSprint) {
-        TickSpeed::shouldInterruptSprint = false;
-        *realSprintTicks = -1;
-    } else if (isDoneSprinting(realSprintTicks)) {
-        *realSprintTicks = -1;
-        TickSpeed::finishSprint();
-    } else if (isDoneStepping(realSprintTicks)) {
-        *realSprintTicks = -1;
-        TickSpeed::stepTicks = 0;
-    }
-    if (*realSprintTicks == 0) {
-        *realSprintTicks = -1;
-    }
-    minecraftAdvanceTicksFn(timer, advance);
-}
-
 inline float TickSpeed::targetTickRate = 20.0;
 inline bool TickSpeed::isFrozen = false;
 inline endstone::CommandSender *TickSpeed::freezeSender = nullptr;
 inline int TickSpeed::stepTicks = 0;
-inline bool TickSpeed::shouldStartStepping = false;
 inline int TickSpeed::sprintTicks = 0;
 inline bool TickSpeed::shouldInterruptSprint = false;
 inline std::chrono::time_point<std::chrono::system_clock> TickSpeed::sprintStartDate;
 inline endstone::Server *TickSpeed::server;
 inline endstone::Logger *TickSpeed::logger;
 
+void timerHook(void *timer, float advance) {
+    auto *realTickRate = reinterpret_cast<float *>(reinterpret_cast<char *>(timer) + 0x0);
+    *realTickRate = TickSpeed::targetTickRate;
+    if (TickSpeed::isStepping()) {
+        *realTickRate = 20.0;
+    } else if (TickSpeed::isFrozen) {
+        *realTickRate = 0.0;
+    }
+
+    auto *realSprintTicks = reinterpret_cast<int32_t *>(reinterpret_cast<char *>(timer) + 0x3C);
+    if (TickSpeed::shouldStartSprint(realSprintTicks)) {
+        *realSprintTicks = TickSpeed::sprintTicks;
+    } else if (TickSpeed::shouldInterruptSprint) {
+        TickSpeed::shouldInterruptSprint = false;
+        *realSprintTicks = -1;
+    } else if (TickSpeed::isDoneSprinting(realSprintTicks)) {
+        *realSprintTicks = -1;
+        TickSpeed::finishSprint();
+    }
+
+    if (*realSprintTicks == 0) {
+        *realSprintTicks = -1;
+    }
+    minecraftAdvanceTicksFn(timer, advance);
+}
+
+void tickHook(void *level) {
+    if (TickSpeed::isStepping()) {
+        TickSpeed::stepTicks--;
+    }
+    minecraftLevelTickFn(level);
+}
+
 inline void TickSpeed::hook(void *baseAddress, funchook_t *funchook) {
 #ifdef __GNUC__
     void *tickAddr = (char *)baseAddress + 135866944; // address of "_ZN5Level4tickEv"
 #else
     void *tpsAddr = (char *)baseAddress + 40916688; // address of "?advanceTime@Timer@@QEAAXM@Z"
+    void *tickAddr = (char *)baseAddress + 44663120; // address of "?tick@Level@@UEAAXXZ"
 #endif
     minecraftAdvanceTicksFn = (void(*)(void*, float))tpsAddr;
     int errorCode = funchook_prepare(funchook, (void **)&minecraftAdvanceTicksFn, timerHook);
+    if (errorCode) {
+        logger->error("Failed to prepare hook: {}", funchook_error_message(funchook));
+    }
+    minecraftLevelTickFn = (void(*)(void*))tickAddr;
+    errorCode = funchook_prepare(funchook, (void **)&minecraftLevelTickFn, tickHook);
     if (errorCode) {
         logger->error("Failed to prepare hook: {}", funchook_error_message(funchook));
     }

--- a/include/TickCommandExecutor.h
+++ b/include/TickCommandExecutor.h
@@ -6,6 +6,8 @@
 
 class TickCommandExecutor : public endstone::CommandExecutor {
 public:
+    explicit TickCommandExecutor(endstone::Plugin &plugin) : plugin(plugin) {}
+
     bool onCommand(endstone::CommandSender &sender, const endstone::Command &command,
              const std::vector<std::string> &args) override {
         if (args[0] == "query") {
@@ -52,7 +54,7 @@ private:
         else
             message += "\n";
 
-        message += fmt::format("§7Average time per tick: {:.1f}ms", TickSpeed::server->getAverageMillisecondsPerTick());
+        message += fmt::format("§7Average time per tick: {:.1f}ms", plugin.getServer().getAverageMillisecondsPerTick());
         if (!TickSpeed::isSprinting())
             message += fmt::format(" (Target: {:.1f}ms)\n", 1000.0 / TickSpeed::targetTickRate);
         else
@@ -61,9 +63,9 @@ private:
     }
 
     void setRate(endstone::CommandSender &sender, const std::vector<std::string> &args) {
-        double minRate = 0;
-        double maxRate = 1000;
-        double rate = std::stod(args[1]);
+        float minRate = 0;
+        float maxRate = 1000;
+        float rate = std::stof(args[1]);
         if (rate <= minRate) {
             sender.sendMessage("§cThe tick rate must not be less than or equal to {:.1f}, found {}.", minRate, rate);
             return;
@@ -73,7 +75,7 @@ private:
             return;
         }
         TickSpeed::setRate(rate);
-        sender.sendMessage("§7Set the target tick rate to {}.", args[1]);
+        plugin.getServer().broadcastMessage("§7Set the target tick rate to {}.", args[1]);
     }
 
     void freeze(endstone::CommandSender &sender) {
@@ -81,13 +83,13 @@ private:
             unfreeze(sender);
         } else {
             TickSpeed::freeze(sender);
-            sender.sendMessage("§7The game is frozen.");
+            plugin.getServer().broadcastMessage("§7The game is frozen.");
         }
     }
 
     void unfreeze(endstone::CommandSender &sender) {
         TickSpeed::unfreeze();
-        sender.sendMessage("§7The game is running normally.");
+        plugin.getServer().broadcastMessage("§7The game is running normally.");
     }
 
     void step(endstone::CommandSender &sender, const std::vector<std::string> &args) {
@@ -106,7 +108,7 @@ private:
             return;
         }
         TickSpeed::step(ticks);
-        sender.sendMessage("§7Stepping {} tick(s).", std::to_string(ticks));
+        plugin.getServer().broadcastMessage("§7Stepping {} tick(s).", std::to_string(ticks));
     }
 
     void sprint(endstone::CommandSender &sender, const std::vector<std::string> &args) {
@@ -116,9 +118,11 @@ private:
             ticks = std::stoi(args[1]);
         }
         if (ticks < minAllowed) {
-            sender.sendMessage("§cThe tick count must not be less than {}, found {}.", minAllowed, ticks);
+            plugin.getServer().broadcastMessage("§cThe tick count must not be less than {}, found {}.", minAllowed, ticks);
             return;
         }
         TickSpeed::sprint(sender, ticks);
     }
+private:
+    endstone::Plugin &plugin;
 };

--- a/include/TickCommandExecutor.h
+++ b/include/TickCommandExecutor.h
@@ -107,7 +107,7 @@ private:
 
     void sprint(endstone::CommandSender &sender, const std::vector<std::string> &args) {
         int ticks = 1;
-        int minAllowed = 1;
+        int minAllowed = 0;
         if (args.size() > 1) {
             ticks = std::stoi(args[1]);
         }

--- a/include/TickCommandExecutor.h
+++ b/include/TickCommandExecutor.h
@@ -77,8 +77,12 @@ private:
     }
 
     void freeze(endstone::CommandSender &sender) {
-        TickSpeed::freeze();
-        sender.sendMessage("§7The game is frozen.");
+        if (TickSpeed::isFrozen) {
+            unfreeze(sender);
+        } else {
+            TickSpeed::freeze(sender);
+            sender.sendMessage("§7The game is frozen.");
+        }
     }
 
     void unfreeze(endstone::CommandSender &sender) {

--- a/include/boreal.h
+++ b/include/boreal.h
@@ -15,6 +15,8 @@
 #include "hook.h"
 #include "TickCommandExecutor.h"
 
+#include "PlayerQuitListener.h"
+
 class Boreal : public endstone::Plugin {
 public:
     std::unique_ptr<CanopyExtension> canopyExtension;
@@ -41,6 +43,9 @@ public:
         if (auto *command = getCommand("tick")){
             command->setExecutor(std::make_unique<TickCommandExecutor>());
         }
+
+        playerQuitListener = std::make_unique<PlayerQuitListener>(*this);
+        registerEvent(&PlayerQuitListener::onPlayerQuit, *playerQuitListener, endstone::EventPriority::High);
     }
 
     void onDisable() override
@@ -74,4 +79,7 @@ public:
     {
         getLogger().info("{} is passed to ExamplePlugin::onServerLoad", event.getEventName());
     }
+
+private:
+    std::unique_ptr<PlayerQuitListener> playerQuitListener;
 };

--- a/include/boreal.h
+++ b/include/boreal.h
@@ -41,7 +41,7 @@ public:
         TickSpeed::logger = &getLogger();
         TickSpeed::server = &getServer();
         if (auto *command = getCommand("tick")){
-            command->setExecutor(std::make_unique<TickCommandExecutor>());
+            command->setExecutor(std::make_unique<TickCommandExecutor>(*this));
         }
 
         playerQuitListener = std::make_unique<PlayerQuitListener>(*this);

--- a/include/boreal.h
+++ b/include/boreal.h
@@ -21,20 +21,13 @@ class Boreal : public endstone::Plugin {
 public:
     std::unique_ptr<CanopyExtension> canopyExtension;
 
-    void onLoad() override
-    {
-        getLogger().info("Boreal loaded successfully");
-    }
-
     void onEnable() override
     {
         void * baseAddress = getBaseAddress();
-        getLogger().info("Boreal enabled!");
         int rv = install_hooks(baseAddress);
         if (rv != 0){
             getLogger().error("Failed to install hooks.");
         }
-        getLogger().info("Hooks installed!");
 
         this->canopyExtension = std::make_unique<CanopyExtension>(*this);
 
@@ -46,11 +39,6 @@ public:
 
         playerQuitListener = std::make_unique<PlayerQuitListener>(*this);
         registerEvent(&PlayerQuitListener::onPlayerQuit, *playerQuitListener, endstone::EventPriority::High);
-    }
-
-    void onDisable() override
-    {
-        getLogger().info("onDisable is called");
     }
 
     bool onCommand(endstone::CommandSender &sender, const endstone::Command &command,
@@ -73,11 +61,6 @@ public:
 
         sender.sendErrorMessage("Unknown command: /{}", command.getName());
         return false;
-    }
-
-    void onServerLoad(endstone::ServerLoadEvent &event)
-    {
-        getLogger().info("{} is passed to ExamplePlugin::onServerLoad", event.getEventName());
     }
 
 private:


### PR DESCRIPTION
1. Tick speed will unfreeze when the player who froze it logs out. This keeps the server from soft-locking in the described instance.
2. Feedback messages are now broadcast instead of sent only to the sender.
3. Steps are now at 20 tps instead of at sprint speed.